### PR TITLE
Update extract-frames.py to be consistent with directory format

### DIFF
--- a/data/scannet/extract-frames.py
+++ b/data/scannet/extract-frames.py
@@ -17,8 +17,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dataset",
         type=Path,
-        default="datasets/open-eqa-v0.json",
-        help="path to open-eqa dataset (default: /datasets/open-eqa-v0.json)",
+        default="data/open-eqa-v0.json",
+        help="path to open-eqa dataset (default: data/open-eqa-v0.json)",
     )
     parser.add_argument(
         "--scannet-root",


### PR DESCRIPTION
Changed the default path of --dataset to be data/open-eqa-v0.json instead of datasets/open-eqa-v0.json  The default installation instructions do not work.  This one line change makes it consistent with the version on GitHub